### PR TITLE
[FEATURE] #6 User 회원가입시 loginId, nickname 중복체크 api 추가, User Entity 필드 추가 및 필드명 수정

### DIFF
--- a/src/main/java/org/netway/dongnehankki/global/auth/CustomUserDetails.java
+++ b/src/main/java/org/netway/dongnehankki/global/auth/CustomUserDetails.java
@@ -30,7 +30,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getId();
+        return user.getLoginId();
     }
 
     @Override

--- a/src/main/java/org/netway/dongnehankki/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/org/netway/dongnehankki/global/auth/CustomUserDetailsService.java
@@ -15,7 +15,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UnregisteredUserException {
-        return userRepository.findById(username)
+        return userRepository.findByLoginId(username)
                 .map(CustomUserDetails::new)
                 .orElseThrow(UnregisteredUserException::new);
     }

--- a/src/main/java/org/netway/dongnehankki/global/auth/SecurityConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/auth/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(SWAGGER_URLS).permitAll()
-                .requestMatchers("/", "/api/login", "/api/refresh").permitAll()
+                .requestMatchers("/", "/api/login", "/api/refresh","/api/users/check/{loginId}").permitAll()
                 .requestMatchers("/api/customers").permitAll()
                 .requestMatchers("/api/owners").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/org/netway/dongnehankki/global/auth/SecurityConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/auth/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(SWAGGER_URLS).permitAll()
-                .requestMatchers("/", "/api/login", "/api/refresh","/api/users/check/{loginId}").permitAll()
+                .requestMatchers("/", "/api/login", "/api/refresh","/api/users/check/loginId", "/api/users/check/nickname").permitAll()
                 .requestMatchers("/api/customers").permitAll()
                 .requestMatchers("/api/owners").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/org/netway/dongnehankki/global/config/SwaggerConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/config/SwaggerConfig.java
@@ -24,20 +24,18 @@ public class SwaggerConfig {
 		Server server = new Server();
 		server.setUrl(serverUrl);
 
-		// SecurityScheme 정의
 		SecurityScheme securityScheme = new SecurityScheme()
 			.type(SecurityScheme.Type.HTTP)
 			.scheme("bearer")
 			.bearerFormat("JWT");
 
-		// SecurityRequirement 정의 (전역 적용)
 		SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
 		return new OpenAPI()
 			.components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
 			.info(apiInfo())
 			.addServersItem(server)
-			.addSecurityItem(securityRequirement); // SecurityRequirement 추가
+			.addSecurityItem(securityRequirement);
 	}
 
 	private Info apiInfo(){

--- a/src/main/java/org/netway/dongnehankki/global/config/SwaggerConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/config/SwaggerConfig.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springframework.context.annotation.Profile;
 
 @Profile("!test")
@@ -22,10 +24,20 @@ public class SwaggerConfig {
 		Server server = new Server();
 		server.setUrl(serverUrl);
 
+		// SecurityScheme 정의
+		SecurityScheme securityScheme = new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT");
+
+		// SecurityRequirement 정의 (전역 적용)
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
 		return new OpenAPI()
-			.components(new Components())
+			.components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
 			.info(apiInfo())
-			.addServersItem(server);
+			.addServersItem(server)
+			.addSecurityItem(securityRequirement); // SecurityRequirement 추가
 	}
 
 	private Info apiInfo(){

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
         });
 
         String encodedPassword = passwordEncoder.encode(customerSignUpRequest.getPassword());
-        User user = userRepository.save(User.ofCustomer(customerSignUpRequest.getLoginId(), encodedPassword, customerSignUpRequest.getNickname()));
+        User user = userRepository.save(User.ofCustomer(customerSignUpRequest.getLoginId(), encodedPassword, customerSignUpRequest.getNickname(), customerSignUpRequest.getName(), customerSignUpRequest.getPhoneNumber()));
 
         return UserResponse.fromEntity(user);
     }
@@ -61,7 +61,7 @@ public class UserService {
                 .orElseThrow(() -> new UnregisteredStoreException());
 
         String encodedPassword = passwordEncoder.encode(ownerSignUpRequest.getPassword());
-        User user = userRepository.save(User.ofOwner(ownerSignUpRequest.getLoginId(), encodedPassword, ownerSignUpRequest.getNickname(), store));
+        User user = userRepository.save(User.ofOwner(ownerSignUpRequest.getLoginId(), encodedPassword, ownerSignUpRequest.getNickname(), ownerSignUpRequest.getName(), ownerSignUpRequest.getPhoneNumber(), store));
 
         return UserResponse.fromEntity(user);
     }

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -7,7 +7,7 @@ import org.netway.dongnehankki.global.auth.jwt.RefreshToken;
 import org.netway.dongnehankki.global.auth.jwt.RefreshTokenRepository;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
 import org.netway.dongnehankki.user.exception.DuplicateNickNameException;
-import org.netway.dongnehankki.user.exception.DuplicateUserIdException;
+import org.netway.dongnehankki.user.exception.DuplicateLoginIdException;
 import org.netway.dongnehankki.user.exception.InvalidPasswordException;
 import org.netway.dongnehankki.store.exception.UnregisteredStoreException;
 import org.netway.dongnehankki.user.exception.InvalidRefreshTokenException;
@@ -42,36 +42,36 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     public UserResponse customerSignUp(CustomerSignUpRequest customerSignUpRequest){
-        userRepository.findById(customerSignUpRequest.getId()).ifPresent(it -> {
-            throw new DuplicateUserIdException();
+        userRepository.findByLoginId(customerSignUpRequest.getLoginId()).ifPresent(it -> {
+            throw new DuplicateLoginIdException();
         });
 
         String encodedPassword = passwordEncoder.encode(customerSignUpRequest.getPassword());
-        User user = userRepository.save(User.ofCustomer(customerSignUpRequest.getId(), encodedPassword, customerSignUpRequest.getNickname()));
+        User user = userRepository.save(User.ofCustomer(customerSignUpRequest.getLoginId(), encodedPassword, customerSignUpRequest.getNickname()));
 
         return UserResponse.fromEntity(user);
     }
 
     public UserResponse ownerSignUp(OwnerSignUpRequest ownerSignUpRequest) {
-        userRepository.findById(ownerSignUpRequest.getId()).ifPresent(it -> {
-            throw new DuplicateUserIdException();
+        userRepository.findByLoginId(ownerSignUpRequest.getLoginId()).ifPresent(it -> {
+            throw new DuplicateLoginIdException();
         });
 
         Store store = storeRepository.findByStoreId(ownerSignUpRequest.getStoreId())
                 .orElseThrow(() -> new UnregisteredStoreException());
 
         String encodedPassword = passwordEncoder.encode(ownerSignUpRequest.getPassword());
-        User user = userRepository.save(User.ofOwner(ownerSignUpRequest.getId(), encodedPassword, ownerSignUpRequest.getNickname(), store));
+        User user = userRepository.save(User.ofOwner(ownerSignUpRequest.getLoginId(), encodedPassword, ownerSignUpRequest.getNickname(), store));
 
         return UserResponse.fromEntity(user);
     }
 
 
     public LoginResponse login(LoginRequest loginRequest){
-        User user = userRepository.findById(loginRequest.getId())
+        User user = userRepository.findByLoginId(loginRequest.getLoginId())
                 .orElseThrow(UnregisteredUserException::new);
 
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.getId(), loginRequest.getPassword());
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.getLoginId(), loginRequest.getPassword());
 
         Authentication authentication;
         try {

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -159,4 +159,8 @@ public class UserService {
     public boolean checkLoginId(String loginId) {
         return userRepository.findByLoginId(loginId).isEmpty();
     }
+
+    public Boolean checkNickname(String nickname) {
+        return userRepository.findByNickname(nickname).isEmpty();
+    }
 }

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -34,7 +34,7 @@ import org.netway.dongnehankki.store.infrastructure.StoreRepository;
 @RequiredArgsConstructor
 public class UserService {
 
-    private  final UserRepository userRepository;
+    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -154,5 +154,9 @@ public class UserService {
         User savedUser = userRepository.save(user);
 
         return UserResponse.fromEntity(savedUser);
+    }
+
+    public boolean checkLoginId(String loginId) {
+        return userRepository.findByLoginId(loginId).isEmpty();
     }
 }

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -139,8 +139,10 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow(() -> new UnregisteredUserException());
 
         if(updateUserRequest.getNickname() != null){
-            userRepository.findByNickname(updateUserRequest.getNickname()).ifPresent(it -> {
-                throw new DuplicateNickNameException();
+            userRepository.findByNickname(updateUserRequest.getNickname()).ifPresent(foundUser -> {
+                if (!foundUser.getUserId().equals(user.getUserId())) {
+                    throw new DuplicateNickNameException();
+                }
             });
             user.updateNickname(updateUserRequest.getNickname());
         }

--- a/src/main/java/org/netway/dongnehankki/user/domain/User.java
+++ b/src/main/java/org/netway/dongnehankki/user/domain/User.java
@@ -29,7 +29,7 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userId;
 
-		private String loginId;
+	private String loginId;
 
 	private String password;
 
@@ -56,7 +56,7 @@ public class User extends BaseEntity {
 		OWNER, CUSTOMER, ADMIN
 	}
 
-		private User(String loginId, String password, String nickname, String name, String phoneNumber, Role role, Store store) {
+	private User(String loginId, String password, String nickname, String name, String phoneNumber, Role role, Store store) {
 		this.loginId = loginId;
 		this.password = password;
 		this.nickname = nickname;

--- a/src/main/java/org/netway/dongnehankki/user/domain/User.java
+++ b/src/main/java/org/netway/dongnehankki/user/domain/User.java
@@ -29,7 +29,7 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userId;
 
-	private String id;
+		private String loginId;
 
 	private String password;
 
@@ -52,20 +52,20 @@ public class User extends BaseEntity {
 		OWNER, CUSTOMER, ADMIN
 	}
 
-	private User(String id, String password, String nickname, Role role, Store store) {
-		this.id = id;
+		private User(String loginId, String password, String nickname, Role role, Store store) {
+		this.loginId = loginId;
 		this.password = password;
 		this.nickname = nickname;
 		this.role = role;
 		this.store = store;
 	}
 
-	public static User ofCustomer(String id, String password, String nickname){
-		return new User(id, password, nickname, Role.CUSTOMER, null);
+	public static User ofCustomer(String loginId, String password, String nickname){
+		return new User(loginId, password, nickname, Role.CUSTOMER, null);
 	}
 
-	public static User ofOwner(String id, String password, String nickname, Store store){
-		return new User(id, password, nickname, Role.OWNER, store);
+	public static User ofOwner(String loginId, String password, String nickname, Store store){
+		return new User(loginId, password, nickname, Role.OWNER, store);
 	}
 
 	public void updateNickname(String nickname) {

--- a/src/main/java/org/netway/dongnehankki/user/domain/User.java
+++ b/src/main/java/org/netway/dongnehankki/user/domain/User.java
@@ -35,6 +35,10 @@ public class User extends BaseEntity {
 
 	private String nickname;
 
+	private String name;
+
+	private String phoneNumber;
+
 	@Enumerated(EnumType.STRING)
 	private Role role;
 
@@ -52,20 +56,22 @@ public class User extends BaseEntity {
 		OWNER, CUSTOMER, ADMIN
 	}
 
-		private User(String loginId, String password, String nickname, Role role, Store store) {
+		private User(String loginId, String password, String nickname, String name, String phoneNumber, Role role, Store store) {
 		this.loginId = loginId;
 		this.password = password;
 		this.nickname = nickname;
+		this.name = name;
+		this.phoneNumber = phoneNumber;
 		this.role = role;
 		this.store = store;
 	}
 
-	public static User ofCustomer(String loginId, String password, String nickname){
-		return new User(loginId, password, nickname, Role.CUSTOMER, null);
+	public static User ofCustomer(String loginId, String password, String nickname, String name, String phoneNumber){
+		return new User(loginId, password, nickname, name, phoneNumber, Role.CUSTOMER, null);
 	}
 
-	public static User ofOwner(String loginId, String password, String nickname, Store store){
-		return new User(loginId, password, nickname, Role.OWNER, store);
+	public static User ofOwner(String loginId, String password, String nickname, String name, String phoneNumber, Store store){
+		return new User(loginId, password, nickname, name, phoneNumber, Role.OWNER, store);
 	}
 
 	public void updateNickname(String nickname) {

--- a/src/main/java/org/netway/dongnehankki/user/dto/request/CustomerSignUpRequest.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/request/CustomerSignUpRequest.java
@@ -9,4 +9,6 @@ public class CustomerSignUpRequest {
     private String loginId;
     private String password;
     private String nickname;
+    private String name;
+    private String phoneNumber;
 }

--- a/src/main/java/org/netway/dongnehankki/user/dto/request/CustomerSignUpRequest.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/request/CustomerSignUpRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CustomerSignUpRequest {
-    private String id;
+    private String loginId;
     private String password;
     private String nickname;
 }

--- a/src/main/java/org/netway/dongnehankki/user/dto/request/LoginRequest.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/request/LoginRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LoginRequest {
-    private String id;
+    private String loginId;
     private String password;
 }

--- a/src/main/java/org/netway/dongnehankki/user/dto/request/OwnerSignUpRequest.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/request/OwnerSignUpRequest.java
@@ -9,5 +9,7 @@ public class OwnerSignUpRequest {
     private String loginId;
     private String password;
     private String nickname;
+    private String name;
+    private String phoneNumber;
     private Long storeId;
 }

--- a/src/main/java/org/netway/dongnehankki/user/dto/request/OwnerSignUpRequest.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/request/OwnerSignUpRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class OwnerSignUpRequest {
-    private String id;
+    private String loginId;
     private String password;
     private String nickname;
     private Long storeId;

--- a/src/main/java/org/netway/dongnehankki/user/dto/response/UserResponse.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/response/UserResponse.java
@@ -10,12 +10,16 @@ public class UserResponse {
     private Long userId;
     private String loginId;
     private String nickname;
+    private String name;
+    private String phoneNumber;
     private Role role;
     private Long storeId;
 
     public Long getUserId() { return userId; }
     public String getLoginId() { return loginId; }
     public String getNickname() { return nickname; }
+    public String getName() { return name; }
+    public String getPhoneNumber() { return phoneNumber; }
     public Role getRole() { return role; }
     public Long getStoreId() { return storeId; }
 
@@ -31,6 +35,8 @@ public class UserResponse {
             user.getUserId(),
             user.getLoginId(),
             user.getNickname(),
+            user.getName(),
+            user.getPhoneNumber(),
             user.getRole(),
             userStoreId
         );

--- a/src/main/java/org/netway/dongnehankki/user/dto/response/UserResponse.java
+++ b/src/main/java/org/netway/dongnehankki/user/dto/response/UserResponse.java
@@ -1,7 +1,6 @@
 package org.netway.dongnehankki.user.dto.response;
 
 import lombok.AllArgsConstructor;
-import org.netway.dongnehankki.store.domain.Store;
 import org.netway.dongnehankki.user.domain.User;
 import org.netway.dongnehankki.user.domain.User.Role;
 
@@ -9,13 +8,13 @@ import org.netway.dongnehankki.user.domain.User.Role;
 @AllArgsConstructor
 public class UserResponse {
     private Long userId;
-    private String id;
+    private String loginId;
     private String nickname;
     private Role role;
     private Long storeId;
 
     public Long getUserId() { return userId; }
-    public String getId() { return id; }
+    public String getLoginId() { return loginId; }
     public String getNickname() { return nickname; }
     public Role getRole() { return role; }
     public Long getStoreId() { return storeId; }
@@ -30,7 +29,7 @@ public class UserResponse {
 
         return new UserResponse(
             user.getUserId(),
-            user.getId(),
+            user.getLoginId(),
             user.getNickname(),
             user.getRole(),
             userStoreId

--- a/src/main/java/org/netway/dongnehankki/user/exception/DuplicateLoginIdException.java
+++ b/src/main/java/org/netway/dongnehankki/user/exception/DuplicateLoginIdException.java
@@ -3,10 +3,10 @@ package org.netway.dongnehankki.user.exception;
 import org.netway.dongnehankki.global.exception.CustomException;
 import org.springframework.http.HttpStatus;
 
-public class DuplicateUserIdException extends CustomException {
+public class DuplicateLoginIdException extends CustomException {
     private static final String MESSAGE = "이미 사용 중인 ID 입니다.";
 
-    public DuplicateUserIdException() {
+    public DuplicateLoginIdException() {
         super(MESSAGE, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/org/netway/dongnehankki/user/infrastructure/UserRepository.java
+++ b/src/main/java/org/netway/dongnehankki/user/infrastructure/UserRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findById(String id);
+    Optional<User> findByLoginId(String loginId);
 
     Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/org/netway/dongnehankki/user/presentation/UserController.java
+++ b/src/main/java/org/netway/dongnehankki/user/presentation/UserController.java
@@ -40,9 +40,16 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success());
     }
 
-    @GetMapping("/users/check/{loginId}")
-    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateLoginId(@PathVariable String loginId){
+    @GetMapping("/users/check/loginId")
+    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateLoginId(@RequestParam String loginId){
         Boolean isAvailable = userService.checkLoginId(loginId);
+        String message = isAvailable ? "사용 가능합니다." : "이미 사용 중입니다.";
+        return ResponseEntity.ok(ApiResponse.success(isAvailable, message));
+    }
+
+    @GetMapping("/users/check/nickname")
+    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateNickname(@RequestParam String nickname){
+        Boolean isAvailable = userService.checkNickname(nickname);
         String message = isAvailable ? "사용 가능합니다." : "이미 사용 중입니다.";
         return ResponseEntity.ok(ApiResponse.success(isAvailable, message));
     }

--- a/src/main/java/org/netway/dongnehankki/user/presentation/UserController.java
+++ b/src/main/java/org/netway/dongnehankki/user/presentation/UserController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,6 +38,13 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> signUpOwner(@RequestBody OwnerSignUpRequest ownerSignUpRequest) {
         userService.ownerSignUp(ownerSignUpRequest);
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @GetMapping("/users/check/{loginId}")
+    public ResponseEntity<ApiResponse<Boolean>> checkDuplicateLoginId(@PathVariable String loginId){
+        Boolean isAvailable = userService.checkLoginId(loginId);
+        String message = isAvailable ? "사용 가능합니다." : "이미 사용 중입니다.";
+        return ResponseEntity.ok(ApiResponse.success(isAvailable, message));
     }
 
     @PostMapping("/login")

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -71,12 +71,14 @@ public class UserServiceTest {
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
+        String name = "홍길동";
+        String phoneNumber = "010-1234-5678";
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
-        when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(loginId, password));
+        when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(loginId, password, name, phoneNumber));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
 
-        Assertions.assertDoesNotThrow(() -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname)));
+        Assertions.assertDoesNotThrow(() -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname,name,phoneNumber)));
     }
 
     @Test
@@ -84,16 +86,18 @@ public class UserServiceTest {
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
+        String name = "김사장";
+        String phoneNumber = "010-9876-5432";
         Long storeId = 1L;
         Store mockStore = mock(Store.class);
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
-        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(loginId, password,mockStore));
+        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(loginId, password, name, phoneNumber, mockStore));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
         when(mockStore.getStoreId()).thenReturn(storeId);
         when(storeRepository.findByStoreId(storeId)).thenReturn(Optional.of(mockStore));
 
-        Assertions.assertDoesNotThrow(() -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,storeId)));
+        Assertions.assertDoesNotThrow(() -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,name,phoneNumber,storeId)));
     }
 
     @Test
@@ -101,12 +105,14 @@ public class UserServiceTest {
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
+        String name = "홍길동";
+        String phoneNumber = "010-1234-5678";
 
-        User fixture = CustomerUserFixture.get(loginId, password);
+        User fixture = CustomerUserFixture.get(loginId, password, name, phoneNumber);
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
-        Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname)));
+        Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname,name,phoneNumber)));
     }
 
     @Test
@@ -114,27 +120,31 @@ public class UserServiceTest {
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
+        String name = "김사장";
+        String phoneNumber = "010-9876-5432";
         Long storeId = 1L;
         Store mockStore = mock(Store.class);
 
-        User fixture = OwnerUserFixture.get(loginId, password,mockStore);
+        User fixture = OwnerUserFixture.get(loginId, password, name, phoneNumber, mockStore);
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
-        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(loginId, password,mockStore));
+        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(loginId, password, name, phoneNumber, mockStore));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
         when(mockStore.getStoreId()).thenReturn(storeId);
         when(storeRepository.findByStoreId(storeId)).thenReturn(Optional.of(mockStore));
 
-        Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,storeId)));
+        Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,name,phoneNumber,storeId)));
     }
 
     @Test
     void 로그인이_정상적으로_동작하는_경우() {
         String loginId = "id";
         String password = "password";
+        String name = "name";
+        String phoneNumber = "010-1111-1111";
         Long userId = 1L;
 
-        User fixture = CustomerUserFixture.get(loginId, password);
+        User fixture = CustomerUserFixture.get(loginId, password, name, phoneNumber);
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
         AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
@@ -165,9 +175,11 @@ public class UserServiceTest {
     void 로그인시_비밀번호가_틀린_경우() {
         String loginId = "id";
         String password = "password";
+        String name = "name";
+        String phoneNumber = "010-1111-1111";
         String wrongPassword = "wrong_password";
 
-        User fixture = CustomerUserFixture.get(loginId, password);
+        User fixture = CustomerUserFixture.get(loginId, password, name , phoneNumber);
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
         AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
@@ -186,7 +198,7 @@ public class UserServiceTest {
         String newAccessToken = "new_access_token";
         String newRefreshToken = "new_refresh_token";
 
-        User userFixture = CustomerUserFixture.get("loginId", "password");
+        User userFixture = CustomerUserFixture.get("loginId", "password", "name", "010-1111-1111");
 
         RefreshToken storedRefreshToken = RefreshToken.builder()
                 .userId(userId)
@@ -239,7 +251,7 @@ public class UserServiceTest {
     void 고객_회원_수정이_성공적으로_동작하는_경우() {
 
         // given
-        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick");
+        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick" ,"oldName", "010-1111-1111");
         // anyLong() 사용
         given(userRepository.findById(anyLong()))
             .willReturn(Optional.of(existingUser));
@@ -263,7 +275,7 @@ public class UserServiceTest {
 
         // given
         Store mockStore = mock(Store.class);
-        User existingUser = User.ofOwner("loginId", "oldPass", "oldNick", mockStore);
+        User existingUser = User.ofOwner("loginId", "oldPass", "oldNick", "oldName", "010-1111-1111", mockStore);
         // anyLong() 사용
         given(userRepository.findById(anyLong()))
             .willReturn(Optional.of(existingUser));
@@ -286,8 +298,8 @@ public class UserServiceTest {
     @Test
     void 다른_유저가_사용중인_닉네임을_사용하는_경우() {
         // given
-        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick");
-        User anotherUser = User.ofCustomer("anotherLoginId", "pass", "newNick");
+        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick" , "oldName", "010-1111-1111");
+        User anotherUser = User.ofCustomer("anotherLoginId", "pass", "newNick", "newName", "010-2222-2222");
         given(userRepository.findById(anyLong())).willReturn(Optional.of(existingUser));
         given(userRepository.findByNickname("newNick")).willReturn(Optional.of(anotherUser));
 
@@ -301,7 +313,7 @@ public class UserServiceTest {
     void 고객_회원_닉네임만_수정이_성공적으로_동작하는_경우() {
 
         // given
-        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick");
+        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick", "oldName", "010-1111-1111");
         // anyLong() 사용
         given(userRepository.findById(anyLong()))
             .willReturn(Optional.of(existingUser));
@@ -323,7 +335,7 @@ public class UserServiceTest {
     void 고객_회원_패스워드만_수정이_성공적으로_동작하는_경우() {
 
         // given
-        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick");
+        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick","oldName", "010-1111-1111");
         // anyLong() 사용
         given(userRepository.findById(anyLong()))
             .willReturn(Optional.of(existingUser));

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ public class UserServiceTest {
 
     @Test
     void 일반회원_회원가입이_정상적으로_동작하는경우() {
+        // given
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
@@ -78,11 +80,13 @@ public class UserServiceTest {
         when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(loginId, password, name, phoneNumber));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
 
+        // when & then
         Assertions.assertDoesNotThrow(() -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname,name,phoneNumber)));
     }
 
     @Test
     void 사장회원_회원가입이_정상적으로_동작하는경우() {
+        // given
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
@@ -97,34 +101,42 @@ public class UserServiceTest {
         when(mockStore.getStoreId()).thenReturn(storeId);
         when(storeRepository.findByStoreId(storeId)).thenReturn(Optional.of(mockStore));
 
+        // when & then
         Assertions.assertDoesNotThrow(() -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,name,phoneNumber,storeId)));
     }
 
     @Test
     void 회원가입시_loginId_중복체크에서_중복이_없을경우() {
+        // given
         String loginId = "existingId";
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
 
+        // when
         boolean isAvailable = userService.checkLoginId(loginId);
 
+        // then
         assertThat(isAvailable).isTrue();
     }
 
     @Test
     void 회원가입시_loginId_중복체크에서_중복이_있을경우() {
+        // given
         String loginId = "existingId";
         User existingUser = CustomerUserFixture.get(loginId, "password", "name", "010-1111-1111");
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(existingUser));
 
+        // when
         boolean isAvailable = userService.checkLoginId(loginId);
 
+        // then
         assertThat(isAvailable).isFalse();
     }
 
     @Test
     void 일반회원_회원가입시_id가_이미_존재하는_경우() {
+        // given
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
@@ -135,11 +147,13 @@ public class UserServiceTest {
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
+        // when & then
         Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname,name,phoneNumber)));
     }
 
     @Test
     void 사장회원_회원가입시_id가_이미_존재하는_경우() {
+        // given
         String loginId = "id";
         String password = "password";
         String nickname = "nickname";
@@ -156,11 +170,13 @@ public class UserServiceTest {
         when(mockStore.getStoreId()).thenReturn(storeId);
         when(storeRepository.findByStoreId(storeId)).thenReturn(Optional.of(mockStore));
 
+        // when & then
         Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,name,phoneNumber,storeId)));
     }
 
     @Test
     void 로그인이_정상적으로_동작하는_경우() {
+        // given
         String loginId = "id";
         String password = "password";
         String name = "name";
@@ -180,22 +196,26 @@ public class UserServiceTest {
         when(jwtTokenProvider.generateRefreshToken(userId)).thenReturn("dummy_refresh_token");
         when(jwtTokenProvider.getRefreshTokenExpirationMinutes()).thenReturn(1440L); // 24시간
 
+        // when & then
         Assertions.assertDoesNotThrow(() -> userService.login(new LoginRequest(loginId,password)));
     }
 
     @Test
     void 회원가입하지_않은_정보로_로그인하는_경우() {
+        // given
         String loginId = "id";
         String password = "password";
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
 
+        // when & then
         Assertions.assertThrows(
             UnregisteredUserException.class, () -> userService.login(new LoginRequest(loginId,password)));
     }
 
     @Test
     void 로그인시_비밀번호가_틀린_경우() {
+        // given
         String loginId = "id";
         String password = "password";
         String name = "name";
@@ -210,12 +230,14 @@ public class UserServiceTest {
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
             .thenThrow(new BadCredentialsException(""));
 
+        // when & then
         Assertions.assertThrows(
             InvalidPasswordException.class, () -> userService.login(new LoginRequest(loginId, wrongPassword)));
     }
 
     @Test
     void 리프레시_토큰_재발급이_정상적으로_동작하는_경우() {
+        // given
         Long userId = 1L;
         String oldRefreshToken = "old_refresh_token";
         String newAccessToken = "new_access_token";
@@ -237,24 +259,29 @@ public class UserServiceTest {
         when(jwtTokenProvider.generateRefreshToken(userId)).thenReturn(newRefreshToken);
         when(jwtTokenProvider.getRefreshTokenExpirationMinutes()).thenReturn(1440L);
 
+        // when
         LoginResponse response = userService.reissueTokens(oldRefreshToken);
 
+        // then
         Assertions.assertEquals(newAccessToken, response.getAccessToken());
         Assertions.assertEquals(newRefreshToken, response.getRefreshToken());
     }
 
     @Test
     void 유효하지_않은_리프레시_토큰으로_재발급을_요청하는_경우() {
+        // given
         String invalidRefreshToken = "invalid_refresh_token";
 
         // 시나리오 1: 토큰 유효성 검증 실패
         when(jwtTokenProvider.validateToken(invalidRefreshToken)).thenReturn(false);
+        // when & then
         Assertions.assertThrows(InvalidRefreshTokenException.class, () -> userService.reissueTokens(invalidRefreshToken));
 
         // 시나리오 2: Redis에 토큰이 없는 경우
         when(jwtTokenProvider.validateToken(invalidRefreshToken)).thenReturn(true);
         when(jwtTokenProvider.getUserIdFromToken(invalidRefreshToken)).thenReturn(1L);
         when(refreshTokenRepository.findById(1L)).thenReturn(Optional.empty());
+        // when & then
         Assertions.assertThrows(InvalidRefreshTokenException.class, () -> userService.reissueTokens(invalidRefreshToken));
 
         // 시나리오 3: Redis에 저장된 토큰과 요청된 토큰이 일치하지 않는 경우
@@ -267,6 +294,7 @@ public class UserServiceTest {
         when(jwtTokenProvider.validateToken(mismatchedRefreshToken)).thenReturn(true);
         when(jwtTokenProvider.getUserIdFromToken(mismatchedRefreshToken)).thenReturn(1L);
         when(refreshTokenRepository.findById(1L)).thenReturn(Optional.of(storedRefreshToken));
+        // when & then
         Assertions.assertThrows(InvalidRefreshTokenException.class, () -> userService.reissueTokens(mismatchedRefreshToken));
     }
 
@@ -321,10 +349,27 @@ public class UserServiceTest {
     @Test
     void 다른_유저가_사용중인_닉네임을_사용하는_경우() {
         // given
-        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick" , "oldName", "010-1111-1111");
+        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick", "oldName", "010-1111-1111");
+        try {
+            Field field = User.class.getDeclaredField("userId");
+            field.setAccessible(true);
+            field.set(existingUser, 999L);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
         User anotherUser = User.ofCustomer("anotherLoginId", "pass", "newNick", "newName", "010-2222-2222");
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(existingUser));
+        try {
+            Field field = User.class.getDeclaredField("userId");
+            field.setAccessible(true);
+            field.set(anotherUser, 1000L);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        given(userRepository.findById(999L)).willReturn(Optional.of(existingUser));
         given(userRepository.findByNickname("newNick")).willReturn(Optional.of(anotherUser));
+        given(passwordEncoder.encode("newPass")).willReturn("encodedNewPass");
 
         UpdateUserRequest req = new UpdateUserRequest("newPass", "newNick");
 

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -18,7 +16,7 @@ import org.netway.dongnehankki.global.auth.jwt.RefreshTokenRepository;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
 import org.netway.dongnehankki.user.dto.response.UserResponse;
 import org.netway.dongnehankki.user.exception.DuplicateNickNameException;
-import org.netway.dongnehankki.user.exception.DuplicateUserIdException;
+import org.netway.dongnehankki.user.exception.DuplicateLoginIdException;
 import org.netway.dongnehankki.user.exception.InvalidPasswordException;
 import org.netway.dongnehankki.user.exception.InvalidRefreshTokenException;
 import org.netway.dongnehankki.user.exception.UnregisteredUserException;
@@ -70,74 +68,74 @@ public class UserServiceTest {
 
     @Test
     void 일반회원_회원가입이_정상적으로_동작하는경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
         String nickname = "nickname";
 
-        when(userRepository.findById(id)).thenReturn(Optional.empty());
-        when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(id, password));
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(loginId, password));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
 
-        Assertions.assertDoesNotThrow(() -> userService.customerSignUp(new CustomerSignUpRequest(id,password,nickname)));
+        Assertions.assertDoesNotThrow(() -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname)));
     }
 
     @Test
     void 사장회원_회원가입이_정상적으로_동작하는경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
         String nickname = "nickname";
         Long storeId = 1L;
         Store mockStore = mock(Store.class);
 
-        when(userRepository.findById(id)).thenReturn(Optional.empty());
-        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(id, password,mockStore));
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(loginId, password,mockStore));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
         when(mockStore.getStoreId()).thenReturn(storeId);
         when(storeRepository.findByStoreId(storeId)).thenReturn(Optional.of(mockStore));
 
-        Assertions.assertDoesNotThrow(() -> userService.ownerSignUp(new OwnerSignUpRequest(id,password,nickname,storeId)));
+        Assertions.assertDoesNotThrow(() -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,storeId)));
     }
 
     @Test
     void 일반회원_회원가입시_id가_이미_존재하는_경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
         String nickname = "nickname";
 
-        User fixture = CustomerUserFixture.get(id, password);
+        User fixture = CustomerUserFixture.get(loginId, password);
 
-        when(userRepository.findById(id)).thenReturn(Optional.of(fixture));
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
-        Assertions.assertThrows(DuplicateUserIdException.class, () -> userService.customerSignUp(new CustomerSignUpRequest(id,password,nickname)));
+        Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.customerSignUp(new CustomerSignUpRequest(loginId,password,nickname)));
     }
 
     @Test
     void 사장회원_회원가입시_id가_이미_존재하는_경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
         String nickname = "nickname";
         Long storeId = 1L;
         Store mockStore = mock(Store.class);
 
-        User fixture = OwnerUserFixture.get(id, password,mockStore);
+        User fixture = OwnerUserFixture.get(loginId, password,mockStore);
 
-        when(userRepository.findById(id)).thenReturn(Optional.of(fixture));
-        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(id, password,mockStore));
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
+        when(userRepository.save(any())).thenReturn(OwnerUserFixture.get(loginId, password,mockStore));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
         when(mockStore.getStoreId()).thenReturn(storeId);
         when(storeRepository.findByStoreId(storeId)).thenReturn(Optional.of(mockStore));
 
-        Assertions.assertThrows(DuplicateUserIdException.class, () -> userService.ownerSignUp(new OwnerSignUpRequest(id,password,nickname,storeId)));
+        Assertions.assertThrows(DuplicateLoginIdException.class, () -> userService.ownerSignUp(new OwnerSignUpRequest(loginId,password,nickname,storeId)));
     }
 
     @Test
     void 로그인이_정상적으로_동작하는_경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
         Long userId = 1L;
 
-        User fixture = CustomerUserFixture.get(id, password);
-        when(userRepository.findById(id)).thenReturn(Optional.of(fixture));
+        User fixture = CustomerUserFixture.get(loginId, password);
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
         AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
         when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
@@ -149,28 +147,28 @@ public class UserServiceTest {
         when(jwtTokenProvider.generateRefreshToken(userId)).thenReturn("dummy_refresh_token");
         when(jwtTokenProvider.getRefreshTokenExpirationMinutes()).thenReturn(1440L); // 24시간
 
-        Assertions.assertDoesNotThrow(() -> userService.login(new LoginRequest(id,password)));
+        Assertions.assertDoesNotThrow(() -> userService.login(new LoginRequest(loginId,password)));
     }
 
     @Test
     void 회원가입하지_않은_정보로_로그인하는_경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
 
-        when(userRepository.findById(id)).thenReturn(Optional.empty());
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
 
         Assertions.assertThrows(
-            UnregisteredUserException.class, () -> userService.login(new LoginRequest(id,password)));
+            UnregisteredUserException.class, () -> userService.login(new LoginRequest(loginId,password)));
     }
 
     @Test
     void 로그인시_비밀번호가_틀린_경우() {
-        String id = "id";
+        String loginId = "id";
         String password = "password";
         String wrongPassword = "wrong_password";
 
-        User fixture = CustomerUserFixture.get(id, password);
-        when(userRepository.findById(id)).thenReturn(Optional.of(fixture));
+        User fixture = CustomerUserFixture.get(loginId, password);
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
         AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
         when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
@@ -178,7 +176,7 @@ public class UserServiceTest {
             .thenThrow(new BadCredentialsException(""));
 
         Assertions.assertThrows(
-            InvalidPasswordException.class, () -> userService.login(new LoginRequest(id, wrongPassword)));
+            InvalidPasswordException.class, () -> userService.login(new LoginRequest(loginId, wrongPassword)));
     }
 
     @Test
@@ -188,7 +186,7 @@ public class UserServiceTest {
         String newAccessToken = "new_access_token";
         String newRefreshToken = "new_refresh_token";
 
-        User userFixture = CustomerUserFixture.get("id", "password");
+        User userFixture = CustomerUserFixture.get("loginId", "password");
 
         RefreshToken storedRefreshToken = RefreshToken.builder()
                 .userId(userId)
@@ -289,7 +287,7 @@ public class UserServiceTest {
     void 다른_유저가_사용중인_닉네임을_사용하는_경우() {
         // given
         User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick");
-        User anotherUser = User.ofCustomer("anotherId", "pass", "newNick");
+        User anotherUser = User.ofCustomer("anotherLoginId", "pass", "newNick");
         given(userRepository.findById(anyLong())).willReturn(Optional.of(existingUser));
         given(userRepository.findByNickname("newNick")).willReturn(Optional.of(anotherUser));
 

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -77,7 +77,7 @@ public class UserServiceTest {
         String phoneNumber = "010-1234-5678";
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
-        when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(loginId, password, name, phoneNumber));
+        when(userRepository.save(any())).thenReturn(CustomerUserFixture.get(loginId, password,nickname, name, phoneNumber));
         when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
 
         // when & then
@@ -123,12 +123,41 @@ public class UserServiceTest {
     void 회원가입시_loginId_중복체크에서_중복이_있을경우() {
         // given
         String loginId = "existingId";
-        User existingUser = CustomerUserFixture.get(loginId, "password", "name", "010-1111-1111");
+        User existingUser = CustomerUserFixture.get(loginId, "password", "nickname", "name", "010-1111-1111");
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(existingUser));
 
         // when
         boolean isAvailable = userService.checkLoginId(loginId);
+
+        // then
+        assertThat(isAvailable).isFalse();
+    }
+
+    @Test
+    void 회원가입시_nickname_중복체크에서_중복이_없을경우() {
+        // given
+        String nickname = "nickname";
+
+        when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
+
+        // when
+        boolean isAvailable = userService.checkNickname(nickname);
+
+        // then
+        assertThat(isAvailable).isTrue();
+    }
+
+    @Test
+    void 회원가입시_nickname_중복체크에서_중복이_있을경우() {
+        // given
+        String nickname = "nickname";
+        User existingUser = CustomerUserFixture.get("loginId", "password", nickname, "name", "010-1111-1111");
+
+        when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(existingUser));
+
+        // when
+        boolean isAvailable = userService.checkNickname(nickname);
 
         // then
         assertThat(isAvailable).isFalse();
@@ -143,7 +172,7 @@ public class UserServiceTest {
         String name = "홍길동";
         String phoneNumber = "010-1234-5678";
 
-        User fixture = CustomerUserFixture.get(loginId, password, name, phoneNumber);
+        User fixture = CustomerUserFixture.get(loginId, password,nickname, name, phoneNumber);
 
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
@@ -180,10 +209,11 @@ public class UserServiceTest {
         String loginId = "id";
         String password = "password";
         String name = "name";
+        String nickname = "nickname";
         String phoneNumber = "010-1111-1111";
         Long userId = 1L;
 
-        User fixture = CustomerUserFixture.get(loginId, password, name, phoneNumber);
+        User fixture = CustomerUserFixture.get(loginId, password,nickname, name, phoneNumber);
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
         AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
@@ -218,11 +248,12 @@ public class UserServiceTest {
         // given
         String loginId = "id";
         String password = "password";
+        String nickname = "nickname";
         String name = "name";
         String phoneNumber = "010-1111-1111";
         String wrongPassword = "wrong_password";
 
-        User fixture = CustomerUserFixture.get(loginId, password, name , phoneNumber);
+        User fixture = CustomerUserFixture.get(loginId, password, nickname, name, phoneNumber);
         when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(fixture));
 
         AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
@@ -243,7 +274,7 @@ public class UserServiceTest {
         String newAccessToken = "new_access_token";
         String newRefreshToken = "new_refresh_token";
 
-        User userFixture = CustomerUserFixture.get("loginId", "password", "name", "010-1111-1111");
+        User userFixture = CustomerUserFixture.get("loginId", "password", "nickname", "name", "010-1111-1111");
 
         RefreshToken storedRefreshToken = RefreshToken.builder()
                 .userId(userId)

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -101,6 +101,29 @@ public class UserServiceTest {
     }
 
     @Test
+    void 회원가입시_loginId_중복체크에서_중복이_없을경우() {
+        String loginId = "existingId";
+
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.empty());
+
+        boolean isAvailable = userService.checkLoginId(loginId);
+
+        assertThat(isAvailable).isTrue();
+    }
+
+    @Test
+    void 회원가입시_loginId_중복체크에서_중복이_있을경우() {
+        String loginId = "existingId";
+        User existingUser = CustomerUserFixture.get(loginId, "password", "name", "010-1111-1111");
+
+        when(userRepository.findByLoginId(loginId)).thenReturn(Optional.of(existingUser));
+
+        boolean isAvailable = userService.checkLoginId(loginId);
+
+        assertThat(isAvailable).isFalse();
+    }
+
+    @Test
     void 일반회원_회원가입시_id가_이미_존재하는_경우() {
         String loginId = "id";
         String password = "password";

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -454,7 +454,7 @@ public class UserServiceTest {
     }
 
     @Test
-    void 고객_회원_패스워드만_수정하려고_할떄_닉네임은_기존_닉네임을_입력하는_경우_성공적으로_동작하는_경우() {
+    void 고객_회원_패스워드만_수정하려고_할때_닉네임은_기존_닉네임을_입력하는_경우_성공적으로_동작하는_경우() {
 
         // given
         User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick","oldName", "010-1111-1111");

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -353,4 +353,27 @@ public class UserServiceTest {
         assertThat(existingUser.getNickname()).isEqualTo("oldNick");
         assertThat(resp.getNickname()).isEqualTo("oldNick");
     }
+
+    @Test
+    void 고객_회원_패스워드만_수정하려고_할떄_닉네임은_기존_닉네임을_입력하는_경우_성공적으로_동작하는_경우() {
+
+        // given
+        User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick","oldName", "010-1111-1111");
+        // anyLong() 사용
+        given(userRepository.findById(anyLong()))
+            .willReturn(Optional.of(existingUser));
+        given(userRepository.save(any(User.class)))
+            .willAnswer(invocation -> invocation.getArgument(0));
+        given(passwordEncoder.encode("newPass")).willReturn("newPass");
+
+        UpdateUserRequest req = new UpdateUserRequest("newPass", "oldNick");
+
+        // when
+        UserResponse resp = userService.updateUser(999L, req);
+
+        // then
+        assertThat(existingUser.getPassword()).isEqualTo("newPass");
+        assertThat(existingUser.getNickname()).isEqualTo("oldNick");
+        assertThat(resp.getNickname()).isEqualTo("oldNick");
+    }
 }

--- a/src/test/java/org/netway/dongnehankki/user/fixture/CustomerUserFixture.java
+++ b/src/test/java/org/netway/dongnehankki/user/fixture/CustomerUserFixture.java
@@ -5,8 +5,8 @@ import org.netway.dongnehankki.user.domain.User;
 public class CustomerUserFixture {
 
     // Test시 사용하는 가짜 User Entity
-    public static User get(String loginId, String password, String name, String phoneNumber){
-        return User.ofCustomer(loginId, password, "테스트고객", name, phoneNumber);
+    public static User get(String loginId, String password, String nickname, String name, String phoneNumber){
+        return User.ofCustomer(loginId, password, nickname, name, phoneNumber);
     }
 
 }

--- a/src/test/java/org/netway/dongnehankki/user/fixture/CustomerUserFixture.java
+++ b/src/test/java/org/netway/dongnehankki/user/fixture/CustomerUserFixture.java
@@ -5,8 +5,8 @@ import org.netway.dongnehankki.user.domain.User;
 public class CustomerUserFixture {
 
     // Test시 사용하는 가짜 User Entity
-    public static User get(String id, String password){
-        return User.ofCustomer(id, password, "테스트고객");
+    public static User get(String loginId, String password, String name, String phoneNumber){
+        return User.ofCustomer(loginId, password, "테스트고객", name, phoneNumber);
     }
 
 }

--- a/src/test/java/org/netway/dongnehankki/user/fixture/OwnerUserFixture.java
+++ b/src/test/java/org/netway/dongnehankki/user/fixture/OwnerUserFixture.java
@@ -6,8 +6,8 @@ import org.netway.dongnehankki.user.domain.User;
 public class OwnerUserFixture {
 
     // Test시 사용하는 가짜 User Entity
-    public static User get(String id, String password, Store store){
-        return User.ofOwner(id, password, "테스트사장님", store);
+    public static User get(String loginId, String password, String name, String phoneNumber, Store store){
+        return User.ofOwner(loginId, password, "테스트사장님", name, phoneNumber, store);
     }
 
 }

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -51,7 +51,7 @@ public class UserControllerTest {
 
     @Test
     public void 일반회원_회원가입() throws Exception{
-        String id = "username";
+        String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
 
@@ -60,7 +60,7 @@ public class UserControllerTest {
 
         mockMvc.perform(post("/api/customers")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(id, password,nickname)))
+            .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname)))
             .with(csrf())
         ).andDo(print())
             .andExpect(status().isOk());
@@ -68,22 +68,22 @@ public class UserControllerTest {
 
     @Test
     public void 사장회원_회원가입() throws Exception{
-        String id = "username";
+        String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
         Long storeId = 1L;
 
         mockMvc.perform(post("/api/owners")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new OwnerSignUpRequest(id,password,nickname,storeId)))
+                .content(objectMapper.writeValueAsBytes(new OwnerSignUpRequest(loginId,password,nickname,storeId)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isOk());
     }
 
     @Test
-    public void 회원가입시_이미_회원가입된_userName으로_회원가입을_하는경우_에러반환() throws Exception{
-        String id = "username";
+    public void 회원가입시_이미_회원가입된_nickName으로_회원가입을_하는경우_에러반환() throws Exception{
+        String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
 
@@ -91,7 +91,7 @@ public class UserControllerTest {
 
         mockMvc.perform(post("/api/customers")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(id, password,nickname)))
+                .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isBadRequest());
@@ -99,14 +99,14 @@ public class UserControllerTest {
 
     @Test
     public void 로그인() throws Exception{
-        String id = "username";
+        String loginId = "loginId";
         String password = "password";
 
         when(userService.login(any(LoginRequest.class))).thenReturn(mock(LoginResponse.class));
 
         mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new LoginRequest(id, password)))
+                .content(objectMapper.writeValueAsBytes(new LoginRequest(loginId, password)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isOk());
@@ -114,14 +114,14 @@ public class UserControllerTest {
 
     @Test
     public void 로그인시_회원가입이_안된_id를_입력할경우_에러반환() throws Exception{
-        String id = "username";
+        String loginId = "loginId";
         String password = "password";
 
         when(userService.login(any(LoginRequest.class))).thenThrow(new UnregisteredUserException());
 
         mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new LoginRequest(id, password)))
+                .content(objectMapper.writeValueAsBytes(new LoginRequest(loginId, password)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isUnauthorized());
@@ -129,14 +129,14 @@ public class UserControllerTest {
 
     @Test
     public void 로그인시_틀린_PW를_입력할경우_에러반환() throws Exception{
-        String id = "username";
+        String loginId = "loginId";
         String password = "password";
 
         when(userService.login(any(LoginRequest.class))).thenThrow(new InvalidPasswordException());
 
         mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new LoginRequest(id, password)))
+                .content(objectMapper.writeValueAsBytes(new LoginRequest(loginId, password)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isUnauthorized());
@@ -147,7 +147,7 @@ public class UserControllerTest {
     public void 단일_고객_회원_조회() throws Exception{
 
         Long userId = 1L;
-        UserResponse mockUserResponse = new UserResponse(userId, "testId", "testNickname", User.Role.CUSTOMER, null);
+        UserResponse mockUserResponse = new UserResponse(userId, "testLoginId", "testNickname", User.Role.CUSTOMER, null);
         when(userService.findByUserId(any(Long.class))).thenReturn(mockUserResponse);
 
         mockMvc.perform(get("/api/users/{userId}", userId)
@@ -161,11 +161,11 @@ public class UserControllerTest {
     public void 단일_점주_회원_조회() throws Exception{
 
         Long userId = 1L;
-        String id = "ownerId";
+        String loginId = "ownerId";
         String nickname = "점주닉네임";
         Long storeId = 100L;
 
-        UserResponse mockUserResponse = new UserResponse(userId, id, nickname, Role.OWNER, storeId);
+        UserResponse mockUserResponse = new UserResponse(userId, loginId, nickname, Role.OWNER, storeId);
         when(userService.findByUserId(any(Long.class))).thenReturn(mockUserResponse);
 
         mockMvc.perform(get("/api/users/{userId}", userId)

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -143,7 +143,7 @@ public class UserControllerTest {
         when(userService.checkNickname(any(String.class))).thenReturn(true);
 
         //then
-        mockMvc.perform(get("/api/users/check/nickname", nickname)
+        mockMvc.perform(get("/api/users/check/nickname")
                 .param("nickname", nickname)
                 .with(csrf())
             ).andDo(print())
@@ -163,7 +163,7 @@ public class UserControllerTest {
         when(userService.checkNickname(any(String.class))).thenReturn(false);
 
         //then
-        mockMvc.perform(get("/api/users/check/nickname", nickname)
+        mockMvc.perform(get("/api/users/check/nickname")
                 .param("nickname", nickname)
                 .with(csrf())
             ).andDo(print())

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -8,10 +8,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.netway.dongnehankki.global.common.ApiResponse;
 import org.netway.dongnehankki.user.domain.User;
 import org.netway.dongnehankki.user.domain.User.Role;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
@@ -84,6 +86,40 @@ public class UserControllerTest {
             ).andDo(print())
             .andExpect(status().isOk());
     }
+    @Test
+    public void 회원가입시_loginId_중복체크_중복없을경우() throws Exception {
+        String loginId = "loginId";
+
+        when(userService.checkLoginId(any(String.class))).thenReturn(true);
+
+        mockMvc.perform(get("/api/users/check/{loginId}", loginId)
+                .with(csrf())
+            ).andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("success"))
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.message").value("사용 가능합니다."))
+            .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    public void 회원가입시_loginId_중복체크_중복있을경우() throws Exception {
+        String loginId = "existingLoginId";
+
+        when(userService.checkLoginId(any(String.class))).thenReturn(false);
+
+        mockMvc.perform(get("/api/users/check/{loginId}", loginId)
+                .with(csrf())
+            ).andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("success"))
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.message").value("이미 사용 중입니다."))
+            .andExpect(jsonPath("$.data").value(false));
+    }
+
+
+
 
     @Test
     public void 회원가입시_이미_회원가입된_nickName으로_회원가입을_하는경우_에러반환() throws Exception{
@@ -283,6 +319,9 @@ public class UserControllerTest {
             ).andDo(print())
             .andExpect(status().isUnauthorized());
     }
+
+
+
 
 
 

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -103,7 +103,8 @@ public class UserControllerTest {
         when(userService.checkLoginId(any(String.class))).thenReturn(true);
 
         //then
-        mockMvc.perform(get("/api/users/check/{loginId}", loginId)
+        mockMvc.perform(get("/api/users/check/loginId")
+                .param("loginId", loginId)
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isOk())
@@ -122,7 +123,8 @@ public class UserControllerTest {
         when(userService.checkLoginId(any(String.class))).thenReturn(false);
 
         //then
-        mockMvc.perform(get("/api/users/check/{loginId}", loginId)
+        mockMvc.perform(get("/api/users/check/loginId")
+                .param("loginId", loginId)
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isOk())
@@ -135,32 +137,14 @@ public class UserControllerTest {
     @Test
     public void 회원가입시_nickName_중복체크_중복없을경우() throws Exception {
         //given
-        String nickName = "nickName";
+        String nickname = "nickname";
 
         //when
-        when(userService.checkLoginId(any(String.class))).thenReturn(true);
+        when(userService.checkNickname(any(String.class))).thenReturn(true);
 
         //then
-        mockMvc.perform(get("/api/users/check/{nickName}", nickName)
-                .with(csrf())
-            ).andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("success"))
-            .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.message").value("이미 사용 중입니다."))
-            .andExpect(jsonPath("$.data").value(false));
-    }
-
-    @Test
-    public void 회원가입시_nickName_중복체크_중복있을경우() throws Exception {
-        //given
-        String nickName = "nickName";
-
-        //when
-        when(userService.checkLoginId(any(String.class))).thenReturn(false);
-
-        //then
-        mockMvc.perform(get("/api/users/check/{nickName}", nickName)
+        mockMvc.perform(get("/api/users/check/nickname", nickname)
+                .param("nickname", nickname)
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isOk())
@@ -168,6 +152,26 @@ public class UserControllerTest {
             .andExpect(jsonPath("$.code").value("200"))
             .andExpect(jsonPath("$.message").value("사용 가능합니다."))
             .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    public void 회원가입시_nickName_중복체크_중복있을경우() throws Exception {
+        //given
+        String nickname = "nickname";
+
+        //when
+        when(userService.checkNickname(any(String.class))).thenReturn(false);
+
+        //then
+        mockMvc.perform(get("/api/users/check/nickname", nickname)
+                .param("nickname", nickname)
+                .with(csrf())
+            ).andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("success"))
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.message").value("이미 사용 중입니다."))
+            .andExpect(jsonPath("$.data").value(false));
     }
 
     @Test

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -132,8 +132,43 @@ public class UserControllerTest {
             .andExpect(jsonPath("$.data").value(false));
     }
 
+    @Test
+    public void 회원가입시_nickName_중복체크_중복없을경우() throws Exception {
+        //given
+        String nickName = "nickName";
 
+        //when
+        when(userService.checkLoginId(any(String.class))).thenReturn(true);
 
+        //then
+        mockMvc.perform(get("/api/users/check/{nickName}", nickName)
+                .with(csrf())
+            ).andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("success"))
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.message").value("이미 사용 중입니다."))
+            .andExpect(jsonPath("$.data").value(false));
+    }
+
+    @Test
+    public void 회원가입시_nickName_중복체크_중복있을경우() throws Exception {
+        //given
+        String nickName = "nickName";
+
+        //when
+        when(userService.checkLoginId(any(String.class))).thenReturn(false);
+
+        //then
+        mockMvc.perform(get("/api/users/check/{nickName}", nickName)
+                .with(csrf())
+            ).andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("success"))
+            .andExpect(jsonPath("$.code").value("200"))
+            .andExpect(jsonPath("$.message").value("사용 가능합니다."))
+            .andExpect(jsonPath("$.data").value(true));
+    }
 
     @Test
     public void 회원가입시_이미_회원가입된_nickName으로_회원가입을_하는경우_에러반환() throws Exception{

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -54,13 +54,15 @@ public class UserControllerTest {
         String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
+        String name = "name";
+        String phoneNumber = "010-1111-1111";
 
         when(userService.customerSignUp(any(CustomerSignUpRequest.class))).thenReturn(mock(
             UserResponse.class));
 
         mockMvc.perform(post("/api/customers")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname)))
+            .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname, name, phoneNumber)))
             .with(csrf())
         ).andDo(print())
             .andExpect(status().isOk());
@@ -71,11 +73,13 @@ public class UserControllerTest {
         String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
+        String name = "name";
+        String phoneNumber = "010-1111-1111";
         Long storeId = 1L;
 
         mockMvc.perform(post("/api/owners")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new OwnerSignUpRequest(loginId,password,nickname,storeId)))
+                .content(objectMapper.writeValueAsBytes(new OwnerSignUpRequest(loginId,password,nickname,name, phoneNumber,storeId)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isOk());
@@ -86,12 +90,14 @@ public class UserControllerTest {
         String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
+        String name = "name";
+        String phoneNumber = "010-1111-1111";
 
         when(userService.customerSignUp(any(CustomerSignUpRequest.class))).thenThrow(new DuplicateNickNameException());
 
         mockMvc.perform(post("/api/customers")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname)))
+                .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname, name, phoneNumber)))
                 .with(csrf())
             ).andDo(print())
             .andExpect(status().isBadRequest());
@@ -147,7 +153,7 @@ public class UserControllerTest {
     public void 단일_고객_회원_조회() throws Exception{
 
         Long userId = 1L;
-        UserResponse mockUserResponse = new UserResponse(userId, "testLoginId", "testNickname", User.Role.CUSTOMER, null);
+        UserResponse mockUserResponse = new UserResponse(userId, "testLoginId", "testNickname","testName", "010-1111-1111", User.Role.CUSTOMER, null);
         when(userService.findByUserId(any(Long.class))).thenReturn(mockUserResponse);
 
         mockMvc.perform(get("/api/users/{userId}", userId)
@@ -163,9 +169,11 @@ public class UserControllerTest {
         Long userId = 1L;
         String loginId = "ownerId";
         String nickname = "점주닉네임";
+        String name = "name";
+        String phoneNumber = "010-1111-1111";
         Long storeId = 100L;
 
-        UserResponse mockUserResponse = new UserResponse(userId, loginId, nickname, Role.OWNER, storeId);
+        UserResponse mockUserResponse = new UserResponse(userId, loginId, nickname, name, phoneNumber ,Role.OWNER, storeId);
         when(userService.findByUserId(any(Long.class))).thenReturn(mockUserResponse);
 
         mockMvc.perform(get("/api/users/{userId}", userId)
@@ -194,9 +202,11 @@ public class UserControllerTest {
         Long userId = 1L;
         String updatedNickname = "새로운닉네임";
         String newPassword = "newPassword";
+        String newName = "name";
+        String newPhoneNumber = "010-1111-1111";
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest(newPassword, updatedNickname);
 
-        UserResponse mockUpdatedUserResponse = new UserResponse(userId, "testId", updatedNickname, Role.CUSTOMER, null);
+        UserResponse mockUpdatedUserResponse = new UserResponse(userId, "testId", updatedNickname, newName, newPhoneNumber, Role.CUSTOMER, null);
         when(userService.updateUser(any(Long.class), any(UpdateUserRequest.class))).thenReturn(mockUpdatedUserResponse);
 
         mockMvc.perform(patch("/api/users/{userId}", userId)
@@ -216,7 +226,7 @@ public class UserControllerTest {
         String newPassword = "newPassword";
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest(newPassword, updatedNickname);
 
-        UserResponse mockUpdatedUserResponse = new UserResponse(userId, "testId", updatedNickname, Role.OWNER, 1L);
+        UserResponse mockUpdatedUserResponse = new UserResponse(userId, "testId", updatedNickname, "testName", "010-1111-1111", Role.OWNER, 1L);
         when(userService.updateUser(any(Long.class), any(UpdateUserRequest.class))).thenReturn(mockUpdatedUserResponse);
 
         mockMvc.perform(patch("/api/users/{userId}", userId)
@@ -273,9 +283,6 @@ public class UserControllerTest {
             ).andDo(print())
             .andExpect(status().isUnauthorized());
     }
-
-
-
 
 
 

--- a/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/presentation/UserControllerTest.java
@@ -13,7 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.netway.dongnehankki.global.common.ApiResponse;
 import org.netway.dongnehankki.user.domain.User;
 import org.netway.dongnehankki.user.domain.User.Role;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
@@ -53,15 +52,18 @@ public class UserControllerTest {
 
     @Test
     public void 일반회원_회원가입() throws Exception{
+        //given
         String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
         String name = "name";
         String phoneNumber = "010-1111-1111";
 
+        //when
         when(userService.customerSignUp(any(CustomerSignUpRequest.class))).thenReturn(mock(
             UserResponse.class));
 
+        //then
         mockMvc.perform(post("/api/customers")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname, name, phoneNumber)))
@@ -72,6 +74,7 @@ public class UserControllerTest {
 
     @Test
     public void 사장회원_회원가입() throws Exception{
+        //given
         String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
@@ -79,6 +82,11 @@ public class UserControllerTest {
         String phoneNumber = "010-1111-1111";
         Long storeId = 1L;
 
+        //when
+        when(userService.ownerSignUp(any(OwnerSignUpRequest.class))).thenReturn(mock(
+            UserResponse.class));
+
+        //then
         mockMvc.perform(post("/api/owners")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(new OwnerSignUpRequest(loginId,password,nickname,name, phoneNumber,storeId)))
@@ -88,10 +96,13 @@ public class UserControllerTest {
     }
     @Test
     public void 회원가입시_loginId_중복체크_중복없을경우() throws Exception {
+        //given
         String loginId = "loginId";
 
+        //when
         when(userService.checkLoginId(any(String.class))).thenReturn(true);
 
+        //then
         mockMvc.perform(get("/api/users/check/{loginId}", loginId)
                 .with(csrf())
             ).andDo(print())
@@ -104,10 +115,13 @@ public class UserControllerTest {
 
     @Test
     public void 회원가입시_loginId_중복체크_중복있을경우() throws Exception {
+        //given
         String loginId = "existingLoginId";
 
+        //when
         when(userService.checkLoginId(any(String.class))).thenReturn(false);
 
+        //then
         mockMvc.perform(get("/api/users/check/{loginId}", loginId)
                 .with(csrf())
             ).andDo(print())
@@ -123,14 +137,17 @@ public class UserControllerTest {
 
     @Test
     public void 회원가입시_이미_회원가입된_nickName으로_회원가입을_하는경우_에러반환() throws Exception{
+        //given
         String loginId = "loginId";
         String password = "password";
         String nickname = "nickname";
         String name = "name";
         String phoneNumber = "010-1111-1111";
 
+        //when
         when(userService.customerSignUp(any(CustomerSignUpRequest.class))).thenThrow(new DuplicateNickNameException());
 
+        //then
         mockMvc.perform(post("/api/customers")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(new CustomerSignUpRequest(loginId, password,nickname, name, phoneNumber)))
@@ -141,11 +158,14 @@ public class UserControllerTest {
 
     @Test
     public void 로그인() throws Exception{
+        //given
         String loginId = "loginId";
         String password = "password";
 
+        //when
         when(userService.login(any(LoginRequest.class))).thenReturn(mock(LoginResponse.class));
 
+        //then
         mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(new LoginRequest(loginId, password)))
@@ -156,11 +176,14 @@ public class UserControllerTest {
 
     @Test
     public void 로그인시_회원가입이_안된_id를_입력할경우_에러반환() throws Exception{
+        //given
         String loginId = "loginId";
         String password = "password";
 
+        //when
         when(userService.login(any(LoginRequest.class))).thenThrow(new UnregisteredUserException());
 
+        //then
         mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(new LoginRequest(loginId, password)))
@@ -171,11 +194,14 @@ public class UserControllerTest {
 
     @Test
     public void 로그인시_틀린_PW를_입력할경우_에러반환() throws Exception{
+        //given
         String loginId = "loginId";
         String password = "password";
 
+        //when
         when(userService.login(any(LoginRequest.class))).thenThrow(new InvalidPasswordException());
 
+        //then
         mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(new LoginRequest(loginId, password)))
@@ -187,11 +213,14 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 단일_고객_회원_조회() throws Exception{
-
+        //given
         Long userId = 1L;
         UserResponse mockUserResponse = new UserResponse(userId, "testLoginId", "testNickname","testName", "010-1111-1111", User.Role.CUSTOMER, null);
+
+        //when
         when(userService.findByUserId(any(Long.class))).thenReturn(mockUserResponse);
 
+        //then
         mockMvc.perform(get("/api/users/{userId}", userId)
                 .with(csrf())
             ).andDo(print())
@@ -201,17 +230,19 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 단일_점주_회원_조회() throws Exception{
-
+        //given
         Long userId = 1L;
         String loginId = "ownerId";
         String nickname = "점주닉네임";
         String name = "name";
         String phoneNumber = "010-1111-1111";
         Long storeId = 100L;
-
         UserResponse mockUserResponse = new UserResponse(userId, loginId, nickname, name, phoneNumber ,Role.OWNER, storeId);
+
+        //when
         when(userService.findByUserId(any(Long.class))).thenReturn(mockUserResponse);
 
+        //then
         mockMvc.perform(get("/api/users/{userId}", userId)
                 .with(csrf())
             ).andDo(print())
@@ -221,10 +252,13 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 없는_회원_조회시_에러반환() throws Exception{
-
+        //given
         Long userId = 1L;
+
+        //when
         when(userService.findByUserId(any(Long.class))).thenThrow(new UnregisteredUserException());
 
+        //then
         mockMvc.perform(get("/api/users/{userId}", userId)
                 .with(csrf())
             ).andDo(print())
@@ -234,17 +268,19 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 고객_회원_수정() throws Exception{
-
+        //given
         Long userId = 1L;
         String updatedNickname = "새로운닉네임";
         String newPassword = "newPassword";
         String newName = "name";
         String newPhoneNumber = "010-1111-1111";
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest(newPassword, updatedNickname);
-
         UserResponse mockUpdatedUserResponse = new UserResponse(userId, "testId", updatedNickname, newName, newPhoneNumber, Role.CUSTOMER, null);
+
+        //when
         when(userService.updateUser(any(Long.class), any(UpdateUserRequest.class))).thenReturn(mockUpdatedUserResponse);
 
+        //then
         mockMvc.perform(patch("/api/users/{userId}", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(userUpdateRequest))
@@ -256,15 +292,17 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 점주_회원_수정() throws Exception{
-
+        //given
         Long userId = 1L;
         String updatedNickname = "새로운닉네임";
         String newPassword = "newPassword";
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest(newPassword, updatedNickname);
-
         UserResponse mockUpdatedUserResponse = new UserResponse(userId, "testId", updatedNickname, "testName", "010-1111-1111", Role.OWNER, 1L);
+
+        //when
         when(userService.updateUser(any(Long.class), any(UpdateUserRequest.class))).thenReturn(mockUpdatedUserResponse);
 
+        //then
         mockMvc.perform(patch("/api/users/{userId}", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(userUpdateRequest))
@@ -276,12 +314,15 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 회원_수정시_빈_닉네임_입력시_에러반환() throws Exception {
+        //given
         Long userId = 1L;
         String updatedNickname = "";
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest(null, updatedNickname);
 
+        //when
         when(userService.updateUser(any(Long.class), any(UpdateUserRequest.class))).thenThrow(new EmptyNickNameException());
 
+        //then
         mockMvc.perform(patch("/api/users/{userId}", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(userUpdateRequest))
@@ -292,9 +333,11 @@ public class UserControllerTest {
 
     @Test
     public void 인증되지_않은_회원이_수정시_에러반환() throws Exception {
+        //given
         Long userId = 1L;
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest("password", "nickname");
 
+        //when & then
         mockMvc.perform(patch("/api/users/{userId}", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(userUpdateRequest))
@@ -306,12 +349,15 @@ public class UserControllerTest {
     @Test
     @WithMockUser
     public void 등록되지_않은_회원_수정시_에러반환() throws Exception {
+        //given
         Long userId = 1L;
         String updatedNickname = "nickname";
         UpdateUserRequest userUpdateRequest = new UpdateUserRequest(null, updatedNickname);
 
+        //when
         when(userService.updateUser(any(Long.class), any(UpdateUserRequest.class))).thenThrow(new UnregisteredUserException());
 
+        //then
         mockMvc.perform(patch("/api/users/{userId}", userId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(userUpdateRequest))


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
#6 
## 📝 변경사항
<!-- 주요 변경사항을 간단히 설명해주세요 -->
1. User Entity에서 id 필드의 필드명을 loginId로 수정
2. Swagger AccessToken 입력 버튼 추가
3. User Test Code BDD 형식 주석 추가
4. User 회원가입시 loginId, nickname 중복체크 api 추가

## 🔍 변경 이유
<!-- 이 변경이 필요한 이유를 설명해주세요 -->
1. Id 필드명이 유저 구분을 위한 userId 와 혼동의 여지가 있음
2. swagger에서 인증이 필요한 api 요청 보낼 시 토큰 정보 입력이 필요하기에 버튼 추가
3. 테스트 코드에 given, when, then 주석 추가
4. 회원가입시 필요하기에 추가

## ✅ 체크리스트
<!-- PR 전 확인해야 할 사항들입니다 -->
- [x] 코드 컨벤션을 준수했나요?
- [x] 테스트 코드를 작성했나요?
- [x] 문서를 업데이트했나요?
- [x] 불필요한 주석이나 코드를 제거했나요?

## 💻 테스트 방법
<!-- 테스트 방법을 설명해주세요 -->
1. loginId 중복체크, (중복 유무)
2. nickname 중복체크, (중복 유무)
3.

## 📌 참고사항
<!-- 기타 참고할 만한 내용을 작성해주세요 -->


