### PR TITLE
[BUG]#32 Jpa, Redis Config 변경

### DIFF
--- a/src/main/java/org/netway/dongnehankki/DongneHankkiBeApplication.java
+++ b/src/main/java/org/netway/dongnehankki/DongneHankkiBeApplication.java
@@ -2,7 +2,6 @@ package org.netway.dongnehankki;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class DongneHankkiBeApplication {

--- a/src/main/java/org/netway/dongnehankki/global/config/JpaConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/config/JpaConfig.java
@@ -1,9 +1,14 @@
 package org.netway.dongnehankki.global.config;
 
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "org.netway.dongnehankki",
+	excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.netway.dongnehankki.global.auth.jwt.*Repository"))
 @Configuration
 public class JpaConfig {
 }

--- a/src/main/java/org/netway/dongnehankki/global/config/RedisConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/config/RedisConfig.java
@@ -1,0 +1,9 @@
+package org.netway.dongnehankki.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories(basePackages = "org.netway.dongnehankki.global.auth.jwt")
+public class RedisConfig {
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
#32 
## 📝 변경사항
<!-- 주요 변경사항을 간단히 설명해주세요 -->
Jpa, Redis Config 변경
## 🔍 변경 이유
<!-- 이 변경이 필요한 이유를 설명해주세요 -->
배포 서버 환경에서  Spring Data JPA와 Spring Data Redis 두 가지 데이터 모듈이 함께 사용되고 있음. 
이 경우, Spring은 어떤 Repository가 JPA를 위한 것이고 어떤 것이 Redis를 위한 것인지 명확하게 구분해야 함


 하지만 로그를 보면 Spring이 StoreRepository와 UserRepository를 어느 데이터 모듈에 할당해야 할지 결정하지 못하고 있음.
이 Repository들은 JPA를 위한 것인데, Redis 모듈이 자신에게 할당해야 할지 혼란스러워하는 상황


이러한 설정 충돌로 인해 애플리케이션의 일부, 특히 Repository에 의존하는 Bean들이 정상적으로 생성되지 않았을 가능성이 있음.ScheduleConfig는 StoreSyncService에 의존하고, StoreSyncService는 StoreRepository에 의존하므로, StoreRepository의
  초기화 문제 때문에 ScheduleConfig의 스케줄러와 이벤트 리스너가 아예 등록되지 않은 것으로 보임


## ✅ 체크리스트
<!-- PR 전 확인해야 할 사항들입니다 -->
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [ ] 불필요한 주석이나 코드를 제거했나요?

## 💻 테스트 방법
<!-- 테스트 방법을 설명해주세요 -->
1.
2.
3.

## 📌 참고사항
<!-- 기타 참고할 만한 내용을 작성해주세요 -->


