### PR TITLE
[Feature] #61 마케팅 푸시알림 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 ### env file ###
 application-local.yml
 application-prod.yml
+dongnehankki-firebase-adminsdk-fbsvc-91e172f41b.json

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 
 	implementation 'net.nurigo:sdk:4.3.2'
 
+	implementation 'com.google.firebase:firebase-admin:9.3.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.h2database:h2'

--- a/src/main/java/org/netway/dongnehankki/global/config/FcmConfig.java
+++ b/src/main/java/org/netway/dongnehankki/global/config/FcmConfig.java
@@ -1,0 +1,42 @@
+package org.netway.dongnehankki.global.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+	@Value("${fcm.secret}")
+	private String path;
+
+	@PostConstruct
+	public void initialize() {
+		try {
+			ClassPathResource resource = new ClassPathResource(path);
+			try (InputStream stream = resource.getInputStream()) {
+				FirebaseOptions options = FirebaseOptions.builder()
+					.setCredentials(GoogleCredentials.fromStream(stream))
+					.build();
+
+				if (FirebaseApp.getApps().isEmpty()) {
+					FirebaseApp.initializeApp(options);
+					log.info("Firebase app has been initialized successfully.");
+				}
+			}
+		} catch (IOException e) {
+			log.error("Error initializing Firebase app", e);
+		}
+	}
+}

--- a/src/main/java/org/netway/dongnehankki/notification/application/FCMNotificationService.java
+++ b/src/main/java/org/netway/dongnehankki/notification/application/FCMNotificationService.java
@@ -1,0 +1,39 @@
+package org.netway.dongnehankki.notification.application;
+
+import java.util.List;
+
+import org.netway.dongnehankki.notification.dto.request.FCMNotificationRequest;
+import org.netway.dongnehankki.user.infrastructure.UserRepository;
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FCMNotificationService {
+
+	public void sendFCMNotifications(String deviceToken, String title, String body) {
+		Notification notification = Notification.builder()
+			.setTitle(title)
+			.setBody(body)
+			.build();
+	
+		//TODO: key value값 프론트랑 상의해서 필요한 값으로 변경
+		Message message = Message.builder()
+			.setToken(deviceToken)
+			.setNotification(notification)
+			.putData("key", "value") 
+			.build();
+
+		try {
+			String response = FirebaseMessaging.getInstance().send(message);
+			System.out.println("Successfully sent message to token " + deviceToken + ": " + response);
+		} catch (Exception e) {
+			System.err.println("Error sending message to token " + deviceToken + ": " + e.getMessage());
+		}
+	}
+}

--- a/src/main/java/org/netway/dongnehankki/notification/application/FCMNotificationService.java
+++ b/src/main/java/org/netway/dongnehankki/notification/application/FCMNotificationService.java
@@ -1,9 +1,5 @@
 package org.netway.dongnehankki.notification.application;
 
-import java.util.List;
-
-import org.netway.dongnehankki.notification.dto.request.FCMNotificationRequest;
-import org.netway.dongnehankki.user.infrastructure.UserRepository;
 import org.springframework.stereotype.Service;
 
 import com.google.firebase.messaging.FirebaseMessaging;

--- a/src/main/java/org/netway/dongnehankki/notification/application/NotificationSchedulingService.java
+++ b/src/main/java/org/netway/dongnehankki/notification/application/NotificationSchedulingService.java
@@ -1,0 +1,70 @@
+package org.netway.dongnehankki.notification.application;
+
+import java.util.List;
+
+import org.netway.dongnehankki.user.domain.User;
+import org.netway.dongnehankki.user.infrastructure.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationSchedulingService {
+
+	private final FCMNotificationService fcmNotificationService;
+	private final UserRepository userRepository;
+
+	@Scheduled(cron = "0 0 8 * * ?") // 매일 아침 8시
+	public void scheduleDailyNotificationsForMorning() {
+		List<User> owners = userRepository.findByRole(User.Role.OWNER);
+
+		String title = "오늘의 아침 식사를 준비해보세요!";
+		String body = "새로운 하루를 상쾌하게 시작할 아침 메뉴를 추천하고 공유해보세요!";
+
+		for (User user : owners) {
+			if (user.getFcmToken() != null && !user.getFcmToken().isEmpty()) {
+				fcmNotificationService.sendFCMNotifications(user.getFcmToken(), title, body);
+			}
+		}
+		
+		log.info("아침 마케팅 알림 전송 완료");
+	}
+
+	@Scheduled(cron = "0 0 12 * * ?") // 매일 정오 12시
+	public void scheduleDailyNotificationsForLunch() {
+		List<User> owners = userRepository.findByRole(User.Role.OWNER);
+
+		String title = "점심 메뉴를 추천해보세요!";
+		String body = "점심 시간에 맞는 메뉴 추천 글을 작성해보세요!";
+
+		for(User user : owners) {
+			if (user.getFcmToken() != null && !user.getFcmToken().isEmpty()) {
+				fcmNotificationService.sendFCMNotifications(user.getFcmToken(), title, body);
+			}
+		}
+
+		log.info("점심 마케팅 알림 전송 완료");
+	}
+
+	@Scheduled(cron = "0 0 18 * * ?") // 매일 저녁 6시
+	public void scheduleDailyNotificationsForDinner() {
+		List<User> owners = userRepository.findByRole(User.Role.OWNER);
+
+		String title = "저녁 식사를 준비해보세요!";
+		String body = "하루의 마무리를 함께할 저녁 메뉴를 추천하고 공유해보세요!";
+
+		for(User user : owners) {
+			if (user.getFcmToken() != null && !user.getFcmToken().isEmpty()) {
+				fcmNotificationService.sendFCMNotifications(user.getFcmToken(), title, body);
+			}
+		}
+
+		log.info("저녁 마케팅 알림 전송 완료");
+	}
+
+}

--- a/src/main/java/org/netway/dongnehankki/notification/dto/request/FCMTokenRequest.java
+++ b/src/main/java/org/netway/dongnehankki/notification/dto/request/FCMTokenRequest.java
@@ -1,0 +1,8 @@
+package org.netway.dongnehankki.notification.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FCMTokenRequest {
+	private String token;
+}

--- a/src/main/java/org/netway/dongnehankki/notification/presentation/FCMController.java
+++ b/src/main/java/org/netway/dongnehankki/notification/presentation/FCMController.java
@@ -1,0 +1,32 @@
+package org.netway.dongnehankki.notification.presentation;
+
+import org.netway.dongnehankki.global.auth.CustomUserDetails;
+import org.netway.dongnehankki.global.common.ApiResponse;
+import org.netway.dongnehankki.notification.dto.request.FCMTokenRequest;
+import org.netway.dongnehankki.user.application.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/fcm")
+@RequiredArgsConstructor
+public class FCMController {
+
+	private final UserService userService;
+
+
+	@PatchMapping("/token")
+	public ResponseEntity<ApiResponse<Void>> updateFCMToken(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody FCMTokenRequest fcmTokenRequest
+	) {
+		userService.updateFcmToken(userDetails.getUser().getUserId(), fcmTokenRequest);
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+}

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -5,6 +5,7 @@ import org.netway.dongnehankki.global.auth.CustomUserDetails;
 import org.netway.dongnehankki.global.auth.jwt.JwtTokenProvider;
 import org.netway.dongnehankki.global.auth.jwt.RefreshToken;
 import org.netway.dongnehankki.global.auth.jwt.RefreshTokenRepository;
+import org.netway.dongnehankki.notification.dto.request.FCMTokenRequest;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
 import org.netway.dongnehankki.user.exception.DuplicateNickNameException;
 import org.netway.dongnehankki.user.exception.DuplicateLoginIdException;
@@ -170,4 +171,10 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow(() -> new UnregisteredUserException());
         user.markAsDeleted();
     }
+
+    @Transactional
+	public void updateFcmToken(Long userId, FCMTokenRequest fcmTokenRequest) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UnregisteredUserException());
+        user.updateFcmToken(fcmTokenRequest.getToken());
+	}
 }

--- a/src/main/java/org/netway/dongnehankki/user/domain/User.java
+++ b/src/main/java/org/netway/dongnehankki/user/domain/User.java
@@ -42,6 +42,8 @@ public class User extends BaseEntity {
 
 	private String phoneNumber;
 
+	private String fcmToken;
+
 	@Enumerated(EnumType.STRING)
 	private Role role;
 
@@ -83,5 +85,9 @@ public class User extends BaseEntity {
 
 	public void updatePassword(String password) {
 		this.password = password;
+	}
+
+	public void updateFcmToken(String fcmToken) {
+		this.fcmToken = fcmToken;
 	}
 }

--- a/src/main/java/org/netway/dongnehankki/user/infrastructure/UserRepository.java
+++ b/src/main/java/org/netway/dongnehankki/user/infrastructure/UserRepository.java
@@ -1,5 +1,6 @@
 package org.netway.dongnehankki.user.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import org.netway.dongnehankki.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByLoginId(String loginId);
 
     Optional<User> findByNickname(String nickname);
+
+    List<User> findByRole(User.Role role);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: local
   datasource:
-    url: jdbc:mysql://localhost:3306/dongnehankki?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/dongnehankki?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -43,6 +43,9 @@ coolsms:
     key: ${COOLSMS_API_KEY}
     secret: ${COOLSMS_SECRET_KEY}
     number: ${COOLSMS_SENDER_NUMBER}
+
+fcm:
+  secret: ${FCM_FILE_NAME}
 ---
 spring:
   config:

--- a/src/test/java/org/netway/dongnehankki/DongneHankkiBeApplicationTests.java
+++ b/src/test/java/org/netway/dongnehankki/DongneHankkiBeApplicationTests.java
@@ -1,6 +1,7 @@
 package org.netway.dongnehankki;
 
 import org.junit.jupiter.api.Test;
+import org.netway.dongnehankki.notification.application.NotificationSchedulingService;
 import org.netway.dongnehankki.store.application.StoreSyncService;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -16,6 +17,9 @@ class DongneHankkiBeApplicationTests {
 
 	@MockitoBean
 	private StoreSyncService storeSyncService;
+
+	@MockitoBean
+	private NotificationSchedulingService notificationSchedulingService;
 
 	@Test
 	void contextLoads() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -44,3 +44,6 @@ cloud:
       secret-key: 32313s0c3T4FcyWOLewqeqw9vr5pHpwuLQ
     region:
       static: ap-northeast-2
+
+fcm:
+  secret: test.json

--- a/src/test/resources/test.json
+++ b/src/test/resources/test.json
@@ -1,0 +1,13 @@
+{
+  "type": "service_account",
+  "project_id": "dongnehankki",
+  "private_key_id": "22",
+  "private_key": "22",
+  "client_email": "t.com",
+  "client_id": "19",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-fbsvc%40dongnehankki.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
#61

## 📝 변경사항
<!-- 주요 변경사항을 간단히 설명해주세요 -->
* FCM(Firebase Cloud Messaging) 푸시 알림 기능을 추가
* Spring Scheduler를 이용하여 OWNER 역할의 사용자에게 알림을 보낼 시간을 설정
* FCM 토큰을 저장하는 API 엔드포인트를 구현했습니다.
* User 엔티티에 fcmToken 필드를 추가

## 🔍 변경 이유
<!-- 이 변경이 필요한 이유를 설명해주세요 -->
서비스 활성화를 위해 주기적인 마케팅 채널이 필요 OWNER 역할을 가진 사용자들에게 점심, 저녁 시간대에 맞춰 푸시 알림을 보내어 신규 게시글 작성을 유도하고, 서비스 리텐션을 강화하기 위함

## ✅ 체크리스트
<!-- PR 전 확인해야 할 사항들입니다 -->
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [ ] 불필요한 주석이나 코드를 제거했나요?

## 💻 테스트 방법
<!-- 테스트 방법을 설명해주세요 -->
1.
2.
3.

## 📌 참고사항
<!-- 기타 참고할 만한 내용을 작성해주세요 -->
테스트 코드 이후에 작성하겠습니다

