### PR TITLE
[Fix] #69 reviewrepsonse 간소화 및 getter 추가

### DIFF
--- a/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
+++ b/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
@@ -1,25 +1,32 @@
 package org.netway.dongnehankki.store.dto.response;
 
+import java.time.LocalDateTime;
+
 import org.netway.dongnehankki.store.domain.Review;
 import org.netway.dongnehankki.user.dto.response.UserResponse;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
 public class ReviewResponse {
 	private Long reviewId;
 	private String content;
 	private Integer scope;
-	private UserResponse reviewUser;
+	private LocalDateTime createdAt;
+	private Long userId;
+	private String userName;
 
 	public static ReviewResponse fromEntity(Review review) {
-		UserResponse user = UserResponse.fromEntity(review.getUser());
 
 		return ReviewResponse.builder()
 			.reviewId(review.getReviewId())
 			.content(review.getContent())
 			.scope(review.getScope())
-			.reviewUser(user)
+			.createdAt(review.getCreatedAt())
+			.userId(review.getUser().getUserId())
+			.userName(review.getUser().getName())
 			.build();
 	}
 }

--- a/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
+++ b/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
@@ -15,6 +15,7 @@ public class ReviewResponse {
 	private String content;
 	private Integer scope;
 	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 	private Long userId;
 	private String userName;
 
@@ -25,6 +26,7 @@ public class ReviewResponse {
 			.content(review.getContent())
 			.scope(review.getScope())
 			.createdAt(review.getCreatedAt())
+			.updatedAt(review.getUpdatedAt())
 			.userId(review.getUser().getUserId())
 			.userName(review.getUser().getName())
 			.build();


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
#69

## 📝 변경사항
<!-- 주요 변경사항을 간단히 설명해주세요 -->
- ReviewResponse DTO 수정
  UserResponse 전체를 포함하지 않고 userId, userName 필드만 포함하도록 변경
- @Getter 추가하여 Jackson 직렬화 가능하도록 수정
   StoreResponse.fromEntity()에서 리뷰 DTO 변환 시 프록시 직렬화 문제 제거

## 🔍 변경 이유
<!-- 이 변경이 필요한 이유를 설명해주세요 -->
- 리뷰가 있는 스토어 조회 시 Jackson 직렬화 에러 발생 (HttpMessageConversionException)
- 원인: LAZY 로딩된 Review.user 프록시 + DTO에 getter 부재
- 필요한 값만 포함하고 getter 추가로 직렬화 문제 해결

## ✅ 체크리스트
<!-- PR 전 확인해야 할 사항들입니다 -->
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [ ] 불필요한 주석이나 코드를 제거했나요?

## 💻 테스트 방법
<!-- 테스트 방법을 설명해주세요 -->
1.
2.
3.

## 📌 참고사항
<!-- 기타 참고할 만한 내용을 작성해주세요 -->


