### PR TITLE
[Fix] #74 Review 조회 시 탈퇴 User 오류 수정

### DIFF
--- a/src/main/java/org/netway/dongnehankki/store/application/StoreService.java
+++ b/src/main/java/org/netway/dongnehankki/store/application/StoreService.java
@@ -94,7 +94,7 @@ public class StoreService {
 			.findFirst().orElseThrow(() -> new UnregisteredReviewException());
 
 		store.getReviews().remove(reviewToDelete);
-		reviewRepository.delete(reviewToDelete);
+		reviewToDelete.markAsDeleted();
 		storeRepository.save(store);
 	}
 

--- a/src/main/java/org/netway/dongnehankki/store/domain/Review.java
+++ b/src/main/java/org/netway/dongnehankki/store/domain/Review.java
@@ -1,5 +1,6 @@
 package org.netway.dongnehankki.store.domain;
 
+import org.hibernate.annotations.Where;
 import org.netway.dongnehankki.global.common.BaseEntity;
 import org.netway.dongnehankki.user.domain.User;
 
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Where(clause = "deleted_at is NULL")
 @NoArgsConstructor
 public class Review extends BaseEntity {
 	@Id

--- a/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
+++ b/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
@@ -4,12 +4,9 @@ import java.time.LocalDateTime;
 
 import org.netway.dongnehankki.store.domain.Review;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Getter
 @Builder
 public class ReviewResponse {

--- a/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
+++ b/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
@@ -22,16 +22,6 @@ public class ReviewResponse {
 	private String userName;
 
 	public static ReviewResponse fromEntity(Review review) {
-		// Long userId = null;
-		// String userName = "탈퇴한 사용자";
-		//
-		// try{
-		// 	userId = review.getUser().getUserId();
-		// 	userName = review.getUser().getNickname();
-		// }catch(EntityNotFoundException e){
-		// 	log.info("유저 탈퇴 에러:");
-		// }
-
 		return ReviewResponse.builder()
 			.reviewId(review.getReviewId())
 			.content(review.getContent())

--- a/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
+++ b/src/main/java/org/netway/dongnehankki/store/dto/response/ReviewResponse.java
@@ -3,11 +3,13 @@ package org.netway.dongnehankki.store.dto.response;
 import java.time.LocalDateTime;
 
 import org.netway.dongnehankki.store.domain.Review;
-import org.netway.dongnehankki.user.dto.response.UserResponse;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 @Builder
 public class ReviewResponse {
@@ -20,6 +22,15 @@ public class ReviewResponse {
 	private String userName;
 
 	public static ReviewResponse fromEntity(Review review) {
+		// Long userId = null;
+		// String userName = "탈퇴한 사용자";
+		//
+		// try{
+		// 	userId = review.getUser().getUserId();
+		// 	userName = review.getUser().getNickname();
+		// }catch(EntityNotFoundException e){
+		// 	log.info("유저 탈퇴 에러:");
+		// }
 
 		return ReviewResponse.builder()
 			.reviewId(review.getReviewId())

--- a/src/main/java/org/netway/dongnehankki/store/infrastructure/repository/ReviewRepository.java
+++ b/src/main/java/org/netway/dongnehankki/store/infrastructure/repository/ReviewRepository.java
@@ -1,7 +1,11 @@
 package org.netway.dongnehankki.store.infrastructure.repository;
 
+import java.util.List;
+
 import org.netway.dongnehankki.store.domain.Review;
+import org.netway.dongnehankki.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+	List<Review> findAllByUser(User user);
 }

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -177,12 +177,11 @@ public class UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new UnregisteredUserException());
-        user.markAsDeleted();
 
         List<Review> reviews = reviewRepository.findAllByUser(user);
-        for (Review review : reviews) {
-            review.markAsDeleted();
-        }
+        reviews.forEach(Review::markAsDeleted);
+
+        user.markAsDeleted();
     }
 
     @Transactional

--- a/src/main/java/org/netway/dongnehankki/user/application/UserService.java
+++ b/src/main/java/org/netway/dongnehankki/user/application/UserService.java
@@ -1,5 +1,7 @@
 package org.netway.dongnehankki.user.application;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.netway.dongnehankki.global.auth.CustomUserDetails;
 import org.netway.dongnehankki.global.auth.jwt.JwtTokenProvider;
@@ -7,6 +9,8 @@ import org.netway.dongnehankki.global.auth.jwt.RefreshToken;
 import org.netway.dongnehankki.global.auth.jwt.RefreshTokenRepository;
 import org.netway.dongnehankki.global.util.S3Service;
 import org.netway.dongnehankki.notification.dto.request.FCMTokenRequest;
+import org.netway.dongnehankki.store.domain.Review;
+import org.netway.dongnehankki.store.infrastructure.repository.ReviewRepository;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
 import org.netway.dongnehankki.user.exception.DuplicateNickNameException;
 import org.netway.dongnehankki.user.exception.DuplicateLoginIdException;
@@ -45,6 +49,7 @@ public class UserService {
     private final StoreRepository storeRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final S3Service s3Service;
+    private final ReviewRepository reviewRepository;
 
     public UserResponse customerSignUp(CustomerSignUpRequest customerSignUpRequest){
         userRepository.findByLoginId(customerSignUpRequest.getLoginId()).ifPresent(it -> {
@@ -173,6 +178,11 @@ public class UserService {
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new UnregisteredUserException());
         user.markAsDeleted();
+
+        List<Review> reviews = reviewRepository.findAllByUser(user);
+        for (Review review : reviews) {
+            review.markAsDeleted();
+        }
     }
 
     @Transactional

--- a/src/test/java/org/netway/dongnehankki/store/application/StoreServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/store/application/StoreServiceTest.java
@@ -313,7 +313,7 @@ public class StoreServiceTest {
 	}
 
 	@Test
-	@DisplayName("deleteStoreMenu - 유효한 입력값에서 정상 작동")
+	@DisplayName("deleteStoreReview - 유효한 입력값에서 정상 작동")
 	void deleteStoreReview_success() {
 		// Given
 		Long storeId = 1L;
@@ -331,8 +331,8 @@ public class StoreServiceTest {
 
 		// Then
 		verify(storeRepository, times(1)).findById(storeId);
-		verify(reviewRepository, times(1)).delete(any(Review.class));
 		verify(storeRepository, times(1)).save(testStore);
+		verify(testReview, times(1)).markAsDeleted();
 		assertFalse(testStore.getReviews().contains(testReview));
 	}
 

--- a/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
+++ b/src/test/java/org/netway/dongnehankki/user/application/UserServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import org.netway.dongnehankki.global.auth.jwt.RefreshTokenRepository;
 import org.netway.dongnehankki.post.application.VertexAIService;
 import org.netway.dongnehankki.store.application.StoreSyncService;
 import org.netway.dongnehankki.store.exception.UnregisteredStoreException;
+import org.netway.dongnehankki.store.infrastructure.repository.ReviewRepository;
 import org.netway.dongnehankki.user.dto.request.UpdateUserRequest;
 import org.netway.dongnehankki.user.dto.response.UserResponse;
 import org.netway.dongnehankki.user.exception.DuplicateNickNameException;
@@ -54,6 +56,9 @@ public class UserServiceTest {
 
     @Autowired
     private UserService userService;
+
+    @MockitoBean
+    private ReviewRepository reviewRepository;
 
     @MockitoBean
     private UserRepository userRepository;
@@ -549,6 +554,7 @@ public class UserServiceTest {
         User existingUser = User.ofCustomer("loginId", "oldPass", "oldNick","oldName", "010-1111-1111",LocalDate.of(2025,8,22));
 
         given(userRepository.findById(userId)).willReturn(Optional.of(existingUser));
+        given(reviewRepository.findAllByUser(existingUser)).willReturn(Collections.emptyList());
 
         // when
         userService.deleteUser(userId);


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
#74 

## 📝 변경사항
<!-- 주요 변경사항을 간단히 설명해주세요 -->
상점 리뷰 조회 시 해당 user가 탈퇴했으면, 연관 관계 오류 발생하여 review도 모두 softdelete로 수정하였습니다

## 🔍 변경 이유
<!-- 이 변경이 필요한 이유를 설명해주세요 -->
상점 리뷰 조회 시 해당 user가 탈퇴했으면, 연관 관계 오류 발생

## ✅ 체크리스트
<!-- PR 전 확인해야 할 사항들입니다 -->
- [x] 코드 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [ ] 불필요한 주석이나 코드를 제거했나요?

## 💻 테스트 방법
<!-- 테스트 방법을 설명해주세요 -->
1.
2.
3.

## 📌 참고사항
<!-- 기타 참고할 만한 내용을 작성해주세요 -->


