### PR TITLE
[fix]#139 jvm zgc 메모리 인식 오류에 따른 튜닝 옵션 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY src/main/resources/googlecloudkey.json BOOT-INF/classes/
 
 EXPOSE 8083
 
-ENTRYPOINT ["java", "-XX:InitialRAMPercentage=75.0", "-XX:MaxRAMPercentage=75.0", "-XX:+UseZGC", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms1536m", "-Xmx1536m", "-XX:+UseZGC", "-jar", "app.jar"]


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 -->
#139 
## 📝 변경사항
<!-- 주요 변경사항을 간단히 설명해주세요 -->
jvm 튜닝 옵션 수정
## 🔍 변경 이유
<!-- 이 변경이 필요한 이유를 설명해주세요 -->
```bash
   1 [3.322s][error][gc] Forced to lower max Java heap size from 11804M(100%) to 2950M(25%)
   2 [3.322s][error][gc] Failed to allocate initial Java heap (11804M)
```

  이 로그는 ZGC가 활성화되었을 때, 컨테이너의 메모리 제한(-m 2g)을 인식하지 못하고 여전히 호스트 머신의 메모리(약 12GB)를 기준으로
  삼으려고 시도했음을 보여줍니다.

  원인: ZGC와 컨테이너 메모리 인식

  Java 17과 ZGC는 일반적으로 컨테이너 환경을 잘 인식하지만, 특정 환경이나 Java의 마이너 버전에 따라 이 인식이 제대로 되지 않는
  경우가 드물게 발생할 수 있습니다. G1GC에서는 정상적으로 동작했지만 ZGC에서는 이 인식이 실패한 것으로 보입니다.

  즉, ZGC가 컨테이너의 2GB 제한을 무시하고 호스트의 12GB를 기준으로 메모리를 할당하려고 시도하다가 실패하는 것입니다.

 힙 크기를 고정하고 ZGC를 활성화

## ✅ 체크리스트
<!-- PR 전 확인해야 할 사항들입니다 -->
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 테스트 코드를 작성했나요?
- [ ] 문서를 업데이트했나요?
- [ ] 불필요한 주석이나 코드를 제거했나요?

## 💻 테스트 방법
<!-- 테스트 방법을 설명해주세요 -->
1.
2.
3.

## 📌 참고사항
<!-- 기타 참고할 만한 내용을 작성해주세요 -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration for optimized application deployment and resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->